### PR TITLE
[sqitch]: Add inspec tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# sqitch
+
+Sqitch is a database change management application.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,15 +1,95 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.sqitch?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=284&branchName=master)
+
 # sqitch
 
-Sqitch is a database change management application.
+Sqitch is a database change management application..  See [documentation](http://sqitch.org)
 
 ## Maintainers
 
-* The Habitat Maintainers: <humans@habitat.sh>
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
 Binary package
 
-## Usage
+### Use as Dependency
 
-*TODO: Add instructions for usage*
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+
+To add core/sqitch as a dependency, you can add one of the following to your plan file.
+
+#### Buildtime Dependency
+
+> pkg_build_deps=(core/sqitch)
+
+#### Runtime dependency
+
+> pkg_deps=(core/sqitch)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/sqitch --binlink``
+
+will add the following binaries to the PATH:
+
+* /bin/config_data
+* /bin/dbilogstrip
+* /bin/dbiprof
+* /bin/dbiproxy
+* /bin/package-stash-conflicts
+* /bin/shell-quote
+* /bin/sqitch
+
+For example:
+
+```bash
+$ hab pkg install core/sqitch --binlink
+» Installing core/sqitch
+☁ Determining latest version of core/sqitch in the 'stable' channel
+→ Found newer installed version (core/sqitch/0.9994/20200928161241) than remote version (core/sqitch/0.9994/20200404042558)
+→ Using core/sqitch/0.9994/20200928161241
+★ Install of core/sqitch/0.9994/20200928161241 complete with 0 new packages installed.
+» Binlinking dbiproxy from core/sqitch/0.9994/20200928161241 into /bin
+★ Binlinked dbiproxy from core/sqitch/0.9994/20200928161241 to /bin/dbiproxy
+» Binlinking shell-quote from core/sqitch/0.9994/20200928161241 into /bin
+★ Binlinked shell-quote from core/sqitch/0.9994/20200928161241 to /bin/shell-quote
+» Binlinking sqitch from core/sqitch/0.9994/20200928161241 into /bin
+★ Binlinked sqitch from core/sqitch/0.9994/20200928161241 to /bin/sqitch
+» Binlinking dbilogstrip from core/sqitch/0.9994/20200928161241 into /bin
+★ Binlinked dbilogstrip from core/sqitch/0.9994/20200928161241 to /bin/dbilogstrip
+» Binlinking package-stash-conflicts from core/sqitch/0.9994/20200928161241 into /bin
+★ Binlinked package-stash-conflicts from core/sqitch/0.9994/20200928161241 to /bin/package-stash-conflicts
+» Binlinking config_data from core/sqitch/0.9994/20200928161241 into /bin
+★ Binlinked config_data from core/sqitch/0.9994/20200928161241 to /bin/config_data
+» Binlinking dbiprof from core/sqitch/0.9994/20200928161241 into /bin
+★ Binlinked dbiprof from core/sqitch/0.9994/20200928161241 to /bin/dbiprof
+```
+
+#### Using an example binary
+
+You can now use the binary as normal.  For example:
+
+``/bin/sqitch --help`` or ``sqitch --help``
+
+```bash
+$ sqitch --help
+Usage
+      sqitch [--plan-file <file>] [--engine <engine>] [--top-dir <dir> ]
+             [--extension <ext>] [--registry <registry>] [--etc-path]
+             [--quiet] [--verbose] [--version]
+             <command> [<command-options>] [<args>]
+
+Common Commands
+    The most commonly used sqitch commands are:
+
+      add        Add a new change to the plan
+      bundle     Bundle a Sqitch project for distribution
+      checkout   Revert, checkout another VCS branch, and re-deploy changes
+      config     Get and set local, user, or system options
+...
+...
+```

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-plan_name: ''
+plan_name: 'sqitch'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines-package-install-next.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/botanist.yml
+++ b/botanist.yml
@@ -1,3 +1,4 @@
 ---
 owners:
+  - "@irvingpop"
   - "@habitat-sh/habitat-core-plans-maintainers"

--- a/controls/sqitch_exists.rb
+++ b/controls/sqitch_exists.rb
@@ -1,0 +1,35 @@
+title 'Tests to confirm sqitch exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'sqitch')
+
+control 'core-plans-sqitch-exists' do
+  impact 1.0
+  title 'Ensure sqitch exists'
+  desc '
+  Verify sqitch by ensuring bin/sqitch 
+  (1) exists and
+  (2) is executable'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  [
+    "config_data",
+    "dbilogstrip",
+    "dbiprof",
+    "dbiproxy",
+    "package-stash-conflicts",
+    "shell-quote",
+    "sqitch",
+  ].each do |binary_name|
+    command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+    describe file(command_full_path) do
+      it { should exist }
+      it { should be_executable }
+    end
+  end
+end

--- a/controls/sqitch_works.rb
+++ b/controls/sqitch_works.rb
@@ -1,0 +1,68 @@
+title 'Tests to confirm sqitch works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'sqitch')
+
+control 'core-plans-sqitch-works' do
+  impact 1.0
+  title 'Ensure sqitch works as expected'
+  desc '
+  Verify sqitch by ensuring that
+  (1) its installation directory exists 
+  (2) it returns the expected version
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  full_suite = {
+    "config_data" => {
+      command_output_pattern: /Usage:\s+.*config_data\s+\[options\]/,
+    },
+    # strips pid numbers, hex, etc.  See https://docs.oracle.com/cd/E36784_01/html/E36870/dbilogstrip-1.html
+    "dbilogstrip" => {
+      command_suffix: '<(echo "pid#6254")',
+      command_output_pattern: /pidN/,
+    },
+    "dbiprof" => {
+      exit_pattern: /^[^0]/,
+    },
+    # ignoring dbiproxy until issue fixed.  See https://github.com/chef-base-plans/sqitch/issues/2
+    # "dbiproxy" => {},
+    "package-stash-conflicts" => {
+      command_suffix: "",
+      command_output_pattern: /^$/,
+    },
+    "shell-quote" => {
+      command_suffix: "--help 2>&1",
+      command_output_pattern: /usage:\s+shell-quote\s+\[switch\]/,
+      exit_pattern: /^[^0]/,
+    },
+    "sqitch" => {
+      command_suffix: "--version",
+      command_output_pattern: /sqitch\s+\(App::Sqitch\)\s+#{plan_pkg_version}/,
+    },
+  }
+  
+  # Use the following to pull out a subset of the above and test progressiveluy
+  subset = full_suite.select { |key, value| key.to_s.match(/^.*$/) }
+  
+  # over-ride the defaults below with (command_suffix:, io:, Etc)
+  subset.each do |binary_name, value|
+    # set default values if each binary doesn't define an over-ride
+    command_suffix = value.has_key?(:command_suffix) ? "#{value[:command_suffix]}" : "-help"
+    command_output_pattern = value[:command_output_pattern] || /#{binary_name}\s+\[options\]\s+\[files\]/i
+    exit_pattern = value[:exit_pattern] || /^[0]$/ # use /^[^0]{1}\d*$/ for non-zero exit status
+
+    # verify output
+    command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+    describe bash("#{command_full_path} #{command_suffix}") do
+      its('exit_status') { should cmp exit_pattern }
+      its('stdout') { should match command_output_pattern }
+    end
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {plan}
-title: Habitat Core Plan {plan}
+name: sqitch
+title: Habitat Core Plan sqitch
 maintainer: "The Core Planners <chef-core-planners@chef.io>"
-summary: InSpec controls for testing Habitat Core Plan {plan}
+summary: InSpec controls for testing Habitat Core Plan sqitch
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 4.18.108'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,46 @@
+pkg_name=sqitch
+pkg_version=0.9994
+pkg_origin=core
+pkg_license=('MIT')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Sqitch is a database change management application."
+pkg_upstream_url=http://sqitch.org/
+pkg_source=https://cpan.metacpan.org/authors/id/D/DW/DWHEELER/App-Sqitch-${pkg_version}.tar.gz
+pkg_filename=App-Sqitch-${pkg_version}.tar.gz
+pkg_dirname=App-Sqitch-${pkg_version}
+pkg_shasum=24de7770884419f199d24fa2ce81f5e7a27583028f685e6973a06840be00c646
+pkg_deps=(core/glibc core/perl core/local-lib core/cpanminus)
+pkg_build_deps=(core/gcc core/make core/coreutils core/perl core/local-lib core/cpanminus)
+pkg_lib_dirs=(lib)
+pkg_bin_dirs=(bin)
+
+do_setup_environment() {
+  push_runtime_env PERL5LIB "${pkg_prefix}/lib/perl5:${pkg_prefix}/lib/perl5/x86_64-linux-thread-multi"
+}
+
+do_prepare() {
+  eval "$(perl -I"$(pkg_path_for core/local-lib)"/lib/perl5 -Mlocal::lib="$(pkg_path_for core/local-lib)")"
+  # Create a new lib dir in our pacakge for cpanm to house all of its libs
+  eval "$(perl -Mlocal::lib="${pkg_prefix}")"
+
+  cpanm Module::Build
+}
+
+do_build() {
+  perl Build.PL
+}
+
+do_install() {
+  export PERL_MM_USE_DEFAULT=1
+  ./Build installdeps --cpan_client 'cpanm -v --notest' --defaultdeps
+  ./Build
+  ./Build install
+
+  for file in "${pkg_prefix}"/bin/*; do
+    sed -i "1 s,.*,& -I${pkg_prefix}/lib/perl5," "$file"
+  done
+}
+
+do_check() {
+  ./Build test
+}


### PR DESCRIPTION
Add to chef-base-plans

studio tests:

```rspec
Profile: Habitat Core Plan sqitch (sqitch)
Version: 0.1.0
Target:  local://

  ✔  core-plans-sqitch-exists: Ensure sqitch exists
     ✔  Command: `hab pkg path core/sqitch` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/sqitch` stdout is expected not to be empty
     ✔  File /hab/pkgs/core/sqitch/0.9994/20200928161241/bin/sqitch is expected to exist
     ✔  File /hab/pkgs/core/sqitch/0.9994/20200928161241/bin/sqitch is expected to be executable
  ✔  core-plans-sqitch-works: Ensure sqitch works as expected
     ✔  Command: `hab pkg path core/sqitch` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/sqitch` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/core/sqitch/0.9994/20200928161241/bin/sqitch --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/core/sqitch/0.9994/20200928161241/bin/sqitch --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/core/sqitch/0.9994/20200928161241/bin/sqitch --version` stdout is expected to match /sqitch\s+\(App::Sqitch\)\s+0.9994/


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 9 successful, 0 failures, 0 skipped
```